### PR TITLE
Don't recalculate buildNumber regardless of where the buildNumber comes from

### DIFF
--- a/src/main/java/org/codehaus/mojo/build/CreateMojo.java
+++ b/src/main/java/org/codehaus/mojo/build/CreateMojo.java
@@ -187,7 +187,7 @@ public class CreateMojo
     private Map<String, String> providerImplementations;
 
     /**
-     * If set to true, will get the scm revision once for all modules of a multi-module project instead of fetching once
+     * If set to true, will get the build number once for all modules of a multi-module project instead of fetching once
      * for each module.
      *
      * @since 1.0-beta-3
@@ -247,6 +247,18 @@ public class CreateMojo
                 scmManager.setScmProviderImplementation( providerType, providerImplementation );
             }
         }
+
+        // Check if the plugin has already run.
+        if ( project != null )
+        {
+            revision = project.getProperties().getProperty( this.buildNumberPropertyName );
+            if ( this.getRevisionOnlyOnce && revision != null )
+            {
+                getLog().debug( "Revision available from previous execution" );
+                return;
+            }
+        }
+
         Date now = Calendar.getInstance().getTime();
         if ( format != null )
         {
@@ -351,14 +363,6 @@ public class CreateMojo
         }
         else
         {
-            // Check if the plugin has already run.
-            revision = project.getProperties().getProperty( this.buildNumberPropertyName );
-            if ( this.getRevisionOnlyOnce && revision != null )
-            {
-                getLog().debug( "Revision available from previous execution" );
-                return;
-            }
-
             if ( doCheck )
             {
                 // we fail if there are local mods


### PR DESCRIPTION
If 'getRevisionOnlyOnce' == true and we have a buildNumber from a previous run then don't recalculate buildNumber regardless of where the buildNumber comes from.

@khmarbaise, not sure where pull requests should be submitted for the MojoHaus plugins.
I think this is the correct spot. If not, please point me.

This PR allows for the same only run once for multi-module builds for timestamps (and other build numbers) as currently provided for SCM build numbers. The use case is to get the one timestamp build number of all modules in a build.