### PR TITLE
Replace the now invalid codehaus SVN URL

### DIFF
--- a/src/it/MBUILDNUM-85/pom.xml
+++ b/src/it/MBUILDNUM-85/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>buildnumber-maven-plugin-mbuildnum-85</artifactId>
   <version>1.0-SNAPSHOT</version>
   <scm>
-    <developerConnection>scm:svn:http://svn.codehaus.org/mojo/trunk/mojo/buildnumber-maven-plugin/src/it/MBUILDNUM-85</developerConnection>
+    <developerConnection>scm:svn:https://svn.apache.org/repos/asf/maven/pom/tags/apache-17</developerConnection>
   </scm>
   <build>
     <defaultGoal>package</defaultGoal>


### PR DESCRIPTION
The IT would pass, but for the wrong reason: the IT build failed because
the SCM checkout did not work, and not due to the expected mojo error.

Used a random Apache SVN URL as a substitute.