### PR TITLE
fixed a trivial typo in one of the usage examples

### DIFF
--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -292,7 +292,7 @@ Usage
         <version>${project.version}</version>
         <executions>
           <execution>
-            <phase>generate-ressources</phase>
+            <phase>generate-resources</phase>
             <goals>
               <goal>create-metadata</goal>
             </goals>


### PR DESCRIPTION
I spotted a typo on the site and thought I'd fix it. I'm not sure if this is the correct process but it seemed easier than raising an issue.