### PR TITLE
Add project site URL to POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
      This plugin is designed to give you a build number. So when you might make 100 builds of version
      1.0-SNAPSHOT, you can differentiate between them all.
   </description>
+  <url>http://www.mojohaus.org/buildnumber-maven-plugin/</url>
   <inceptionYear>2007</inceptionYear>
   <licenses>
     <license>


### PR DESCRIPTION
As reported in issue#30, without a URL in the POM, the effective URL resolved by
Maven is an invalid location (404) in the project website. This effects pages
generated by Maven Project Info Report's Project Plugin Management report.

Resolves #30.