### PR TITLE
Unify handling of timestampFormat parameter between CreateMojo and CreateTimestampMojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
                     <svn>javasvn</svn>
                   </providerImplementations>
                   <useLastCommittedRevision>true</useLastCommittedRevision>
-                  <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+                  <timestampFormat>yyyy-MM-dd</timestampFormat>
                 </configuration>
               </execution>
             </executions>

--- a/src/it/MBUILDNUM-83/pom.xml
+++ b/src/it/MBUILDNUM-83/pom.xml
@@ -54,7 +54,7 @@
                   <svn>javasvn</svn>
                 </providerImplementations>
                 <useLastCommittedRevision>true</useLastCommittedRevision>
-                <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+                <timestampFormat>yyyy-MM-dd</timestampFormat>
               </configuration>
             </execution>
           </executions>

--- a/src/it/MOJO-1668/dotSvnDir/pristine/85/85ead35ecb9e8e8eabe052fe4b3156db3e83741e.svn-base
+++ b/src/it/MOJO-1668/dotSvnDir/pristine/85/85ead35ecb9e8e8eabe052fe4b3156db3e83741e.svn-base
@@ -49,7 +49,7 @@
          </providerImplementations>
          <username>foo</username>
          <password>bar</password>
-         <timestampFormat>{0,date,yyyyMMdd_HHmmss}</timestampFormat>
+         <timestampFormat>yyyyMMdd_HHmmss</timestampFormat>
        </configuration>
       </plugin>
       <plugin>

--- a/src/it/MOJO-1668/pom.xml
+++ b/src/it/MOJO-1668/pom.xml
@@ -54,7 +54,7 @@
           </providerImplementations>
           <username>foo</username>
           <password>bar</password>
-          <timestampFormat>{0,date,yyyyMMdd_HHmmss}</timestampFormat>
+          <timestampFormat>yyyyMMdd_HHmmss</timestampFormat>
         </configuration>
       </plugin>
       <plugin>

--- a/src/it/basic-it-clearcase-scm/pom.xml
+++ b/src/it/basic-it-clearcase-scm/pom.xml
@@ -43,7 +43,7 @@
             <configuration>
               <revisionOnScmFailure>foo</revisionOnScmFailure>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/it/basic-it-git/pom.xml
+++ b/src/it/basic-it-git/pom.xml
@@ -38,7 +38,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/it/basic-it-no-devscm/dotSvnDir/pristine/b8/b87a2294a5074b47315f9fac29b4930d2a2b7ae5.svn-base
+++ b/src/it/basic-it-no-devscm/dotSvnDir/pristine/b8/b87a2294a5074b47315f9fac29b4930d2a2b7ae5.svn-base
@@ -40,7 +40,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/it/basic-it-no-devscm/dotSvnDir/text-base/pom.xml.svn-base
+++ b/src/it/basic-it-no-devscm/dotSvnDir/text-base/pom.xml.svn-base
@@ -40,7 +40,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/it/basic-it-no-devscm/pom.xml
+++ b/src/it/basic-it-no-devscm/pom.xml
@@ -40,7 +40,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/it/basic-it-svnjava/dotSvnDir/pristine/76/76ff7cf8f7fb9790d8c2819c640d641d4ff2093f.svn-base
+++ b/src/it/basic-it-svnjava/dotSvnDir/pristine/76/76ff7cf8f7fb9790d8c2819c640d641d4ff2093f.svn-base
@@ -45,7 +45,7 @@
                   <svn>javasvn</svn>
                 </providerImplementations>            
                 <useLastCommittedRevision>true</useLastCommittedRevision>
-                <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+                <timestampFormat>yyyy-MM-dd</timestampFormat>
               </configuration>
             </execution>
           </executions>

--- a/src/it/basic-it-svnjava/pom.xml
+++ b/src/it/basic-it-svnjava/pom.xml
@@ -52,7 +52,7 @@
                   <svn>javasvn</svn>
                 </providerImplementations>
                 <useLastCommittedRevision>true</useLastCommittedRevision>
-                <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+                <timestampFormat>yyyy-MM-dd</timestampFormat>
               </configuration>
             </execution>
           </executions>

--- a/src/it/git-basic-it-MBUILDNUM-66/pom.xml
+++ b/src/it/git-basic-it-MBUILDNUM-66/pom.xml
@@ -36,7 +36,7 @@
               <goal>create</goal>
             </goals>
             <configuration>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/org/codehaus/mojo/build/Utils.java
+++ b/src/main/java/org/codehaus/mojo/build/Utils.java
@@ -15,7 +15,13 @@ public class Utils
 
     public static String createTimestamp( String timestampFormat, String timeZoneId)
     {
-        Date now = Calendar.getInstance().getTime();
+        return createTimestamp( timestampFormat, timeZoneId, null);
+    }
+
+    public static String createTimestamp( String timestampFormat, String timeZoneId, Date now)
+    {
+        if ( null == now)
+            now = Calendar.getInstance().getTime();
 
         if ( StringUtils.isBlank( timestampFormat ) )
         {

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -155,7 +155,7 @@ Usage
 
 +------------------------------------------+
     <configuration>
-      <format>{0,date,yyyy-MM-dd HH:mm:ss}</format>
+      <format>yyyy-MM-dd HH:mm:ss</format>
       <items>
         <item>timestamp</item>
       </items>

--- a/src/test/projects/MBUILDNUM-83/pom.xml
+++ b/src/test/projects/MBUILDNUM-83/pom.xml
@@ -54,7 +54,7 @@
                   <svn>javasvn</svn>
                 </providerImplementations>
                 <useLastCommittedRevision>true</useLastCommittedRevision>
-                <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+                <timestampFormat>yyyy-MM-dd</timestampFormat>
               </configuration>
             </execution>
           </executions>

--- a/src/test/projects/MOJO-1668/dotSvnDir/pristine/85/85ead35ecb9e8e8eabe052fe4b3156db3e83741e.svn-base
+++ b/src/test/projects/MOJO-1668/dotSvnDir/pristine/85/85ead35ecb9e8e8eabe052fe4b3156db3e83741e.svn-base
@@ -49,7 +49,7 @@
          </providerImplementations>
          <username>foo</username>
          <password>bar</password>
-         <timestampFormat>{0,date,yyyyMMdd_HHmmss}</timestampFormat>
+         <timestampFormat>yyyyMMdd_HHmmss</timestampFormat>
        </configuration>
       </plugin>
       <plugin>

--- a/src/test/projects/MOJO-1668/pom.xml
+++ b/src/test/projects/MOJO-1668/pom.xml
@@ -54,7 +54,7 @@
           </providerImplementations>
           <username>foo</username>
           <password>bar</password>
-          <timestampFormat>{0,date,yyyyMMdd_HHmmss}</timestampFormat>
+          <timestampFormat>yyyyMMdd_HHmmss</timestampFormat>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/projects/basic-it-clearcase-scm/pom.xml
+++ b/src/test/projects/basic-it-clearcase-scm/pom.xml
@@ -43,7 +43,7 @@
             <configuration>
               <revisionOnScmFailure>foo</revisionOnScmFailure>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/basic-it-no-devscm/dotSvnDir/pristine/b8/b87a2294a5074b47315f9fac29b4930d2a2b7ae5.svn-base
+++ b/src/test/projects/basic-it-no-devscm/dotSvnDir/pristine/b8/b87a2294a5074b47315f9fac29b4930d2a2b7ae5.svn-base
@@ -40,7 +40,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/basic-it-no-devscm/dotSvnDir/text-base/pom.xml.svn-base
+++ b/src/test/projects/basic-it-no-devscm/dotSvnDir/text-base/pom.xml.svn-base
@@ -40,7 +40,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/basic-it-no-devscm/pom.xml
+++ b/src/test/projects/basic-it-no-devscm/pom.xml
@@ -40,7 +40,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/basic-it-svnjava/dotSvnDir/pristine/76/76ff7cf8f7fb9790d8c2819c640d641d4ff2093f.svn-base
+++ b/src/test/projects/basic-it-svnjava/dotSvnDir/pristine/76/76ff7cf8f7fb9790d8c2819c640d641d4ff2093f.svn-base
@@ -45,7 +45,7 @@
                   <svn>javasvn</svn>
                 </providerImplementations>            
                 <useLastCommittedRevision>true</useLastCommittedRevision>
-                <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+                <timestampFormat>yyyy-MM-dd</timestampFormat>
               </configuration>
             </execution>
           </executions>

--- a/src/test/projects/basic-it-svnjava/pom.xml
+++ b/src/test/projects/basic-it-svnjava/pom.xml
@@ -52,7 +52,7 @@
                   <svn>javasvn</svn>
                 </providerImplementations>
                 <useLastCommittedRevision>true</useLastCommittedRevision>
-                <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+                <timestampFormat>yyyy-MM-dd</timestampFormat>
               </configuration>
             </execution>
           </executions>

--- a/src/test/projects/basic-it/dotSvnDir/pristine/be/be81b1b83de4bd67f35fdab9bd4707604ab1c092.svn-base
+++ b/src/test/projects/basic-it/dotSvnDir/pristine/be/be81b1b83de4bd67f35fdab9bd4707604ab1c092.svn-base
@@ -38,7 +38,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/basic-it/dotSvnDir/text-base/pom.xml.svn-base
+++ b/src/test/projects/basic-it/dotSvnDir/text-base/pom.xml.svn-base
@@ -38,7 +38,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/basic-it/pom.xml
+++ b/src/test/projects/basic-it/pom.xml
@@ -38,7 +38,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/git-basic-it-MBUILDNUM-66/pom.xml
+++ b/src/test/projects/git-basic-it-MBUILDNUM-66/pom.xml
@@ -36,7 +36,7 @@
               <goal>create</goal>
             </goals>
             <configuration>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This PR is to address issue #40 
- Update `CreateMojo.java` to use `Utils.createTimestamp()`
- Check value of `timestampFormat` for `MessageFormat` style and warn/convert for backwards compatibility
- Update IT projects with `SimpleDateFormat` style configuration for executions of create goal.
  - leave `basic-it` with `MessageFormat` style so warn/convert behavior is tested too.
