### PR TITLE
Added support for json output format additionally to properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.8.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/codehaus/mojo/build/JsonOutputFormat.java
+++ b/src/main/java/org/codehaus/mojo/build/JsonOutputFormat.java
@@ -1,0 +1,27 @@
+package org.codehaus.mojo.build;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.*;
+import java.util.Properties;
+
+public class JsonOutputFormat extends OutputFormat {
+    @Override
+    public boolean handles(String fileName) {
+        return fileName.endsWith(".json");
+    }
+
+    @Override
+    public void write(Properties props, OutputStream out) throws IOException {
+        Gson gson = new Gson();
+        JsonWriter jsonWriter = gson.newJsonWriter(new OutputStreamWriter( out, "UTF-8" ));
+        jsonWriter.beginObject();
+        for(Object key: props.keySet()) {
+            jsonWriter.name((String)key);
+            jsonWriter.value(props.getProperty((String)key));
+        }
+        jsonWriter.endObject();
+        jsonWriter.flush();
+    }
+}

--- a/src/main/java/org/codehaus/mojo/build/OutputFormat.java
+++ b/src/main/java/org/codehaus/mojo/build/OutputFormat.java
@@ -1,0 +1,29 @@
+package org.codehaus.mojo.build;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Properties;
+
+public abstract class OutputFormat {
+    static final OutputFormat DEFAULT_FORMAT = new PropertiesOutputFormat();
+
+    private static final OutputFormat[] FORMATS = new OutputFormat[] {
+            new JsonOutputFormat(),
+            OutputFormat.DEFAULT_FORMAT
+    };
+
+    public static OutputFormat getOutputFormatFor(String fileName) {
+        for(OutputFormat outputFormat : OutputFormat.FORMATS) {
+            if( outputFormat.handles(fileName) ) {
+                return outputFormat;
+            }
+        }
+
+        return OutputFormat.DEFAULT_FORMAT;
+    }
+
+    public abstract boolean handles(String fileName);
+
+    public abstract void write(Properties props, OutputStream out) throws IOException;
+}

--- a/src/main/java/org/codehaus/mojo/build/PropertiesOutputFormat.java
+++ b/src/main/java/org/codehaus/mojo/build/PropertiesOutputFormat.java
@@ -1,0 +1,19 @@
+package org.codehaus.mojo.build;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Properties;
+
+public class PropertiesOutputFormat extends OutputFormat {
+    @Override
+    public boolean handles(String fileName) {
+        return fileName.endsWith(".properties");
+    }
+
+    @Override
+    public void write(Properties props, OutputStream out) throws IOException {
+        props.store( out, "Created by build system. Do not modify" );
+    }
+}

--- a/src/test/java/org/codehaus/mojo/build/JsonOutputFormatTest.java
+++ b/src/test/java/org/codehaus/mojo/build/JsonOutputFormatTest.java
@@ -1,0 +1,57 @@
+package org.codehaus.mojo.build;
+
+import com.google.gson.Gson;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+/**
+ * Created by conni on 11/10/16.
+ */
+public class JsonOutputFormatTest {
+
+    private OutputFormat outputFormat = new JsonOutputFormat();
+
+    private Properties properties = new Properties();
+
+    private Gson gson = new Gson();
+
+    @Before
+    public void before() {
+        properties.put("key0", "value0");
+        properties.put("key1", "value1");
+    }
+
+    @Test
+    public void handlesDotJson() {
+        assertTrue(outputFormat.handles("file.json"));
+    }
+
+    @Test
+    public void doesNotHandleNonJson() {
+        assertFalse(outputFormat.handles("file.other"));
+    }
+
+    @Test
+    public void writesJson() throws IOException {
+        String s = writePropertiesToString();
+
+        Map<String,Object> map = gson.fromJson(s, Map.class);
+        assertThat(map.size(), is(2));
+        assertThat(map.get("key0"), is((Object)"value0"));
+        assertThat(map.get("key1"), is((Object)"value1"));
+    }
+
+    private String writePropertiesToString() throws IOException {
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        outputFormat.write(properties, bytesOut);
+        return new String(bytesOut.toByteArray(), "UTF-8");
+    }
+}

--- a/src/test/java/org/codehaus/mojo/build/OutputFormatTest.java
+++ b/src/test/java/org/codehaus/mojo/build/OutputFormatTest.java
@@ -1,0 +1,32 @@
+package org.codehaus.mojo.build;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by conni on 11/10/16.
+ */
+public class OutputFormatTest {
+
+    @Test
+    public void defaultIsPropertiesFormat() {
+        OutputFormat outputFormat = OutputFormat.getOutputFormatFor("illegal");
+
+        assertTrue(outputFormat instanceof PropertiesOutputFormat);
+    }
+
+    @Test
+    public void jsonForForDotJson() {
+        OutputFormat outputFormat = OutputFormat.getOutputFormatFor("file.json");
+
+        assertTrue(outputFormat instanceof JsonOutputFormat);
+    }
+
+    @Test
+    public void propertiesForForDotProperties() {
+        OutputFormat outputFormat = OutputFormat.getOutputFormatFor("file.properties");
+
+        assertTrue(outputFormat instanceof PropertiesOutputFormat);
+    }
+}

--- a/src/test/java/org/codehaus/mojo/build/PropertiesOutputFormatTest.java
+++ b/src/test/java/org/codehaus/mojo/build/PropertiesOutputFormatTest.java
@@ -1,0 +1,57 @@
+package org.codehaus.mojo.build;
+
+import com.google.gson.Gson;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+/**
+ * Created by conni on 11/10/16.
+ */
+public class PropertiesOutputFormatTest {
+
+    private OutputFormat outputFormat = new PropertiesOutputFormat();
+
+    private Properties properties = new Properties();
+
+    @Before
+    public void before() {
+        properties.put("key0", "value0");
+        properties.put("key1", "value1");
+    }
+
+    @Test
+    public void handlesDotProperties() {
+        assertTrue(outputFormat.handles("file.properties"));
+    }
+
+    @Test
+    public void doesNotHandleNonProperties() {
+        assertFalse(outputFormat.handles("file.other"));
+    }
+
+    @Test
+    public void writesProperties() throws IOException {
+        byte[] serialized = writeProperties();
+
+        Properties deserializedProperties = new Properties();
+        deserializedProperties.load(new ByteArrayInputStream(serialized));
+
+        assertThat(deserializedProperties, is(properties));
+    }
+
+    private byte[] writeProperties() throws IOException {
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        outputFormat.write(properties, bytesOut);
+        return bytesOut.toByteArray();
+    }
+}

--- a/src/test/java/org/codehaus/mojo/build/it/CreateMetadataMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/build/it/CreateMetadataMojoTest.java
@@ -47,4 +47,23 @@ public class CreateMetadataMojoTest
         Assert.assertTrue( new File( testDir, "target/classes/build.properties" ).exists() );
 
     }
+
+
+    @Test
+    public void testBasicJsonConfiguration()
+            throws Exception
+    {
+        File projDir = resources.getBasedir( "create-metadata-json-it" );
+
+        MavenExecution mavenExec = maven.forProject( projDir );
+        MavenExecutionResult result = mavenExec.execute( "clean", "test" );
+        result.assertErrorFreeLog();
+
+        File testDir = result.getBasedir();
+        Assert.assertTrue( new File( testDir, "target/file1.json" ).exists() );
+        Assert.assertTrue( new File( testDir, "target/xxx/file1.json" ).exists() );
+        Assert.assertTrue( new File( testDir, "target/generated/build-metadata/build.properties" ).exists() );
+        Assert.assertTrue( new File( testDir, "target/classes/build.properties" ).exists() );
+
+    }
 }

--- a/src/test/projects/create-metadata-json-it/pom.xml
+++ b/src/test/projects/create-metadata-json-it/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.it</groupId>
+  <artifactId>build-metadata-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <scm>
+    <developerConnection>scm:svn:http://svn.codehaus.org/mojo/trunk/mojo/buildnumber-maven-plugin/src/test/projects/bogus</developerConnection>
+  </scm>
+
+  <build>
+
+    <defaultGoal>package</defaultGoal>
+
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>${it-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>useLastCommittedRevision</id>
+            <goals>
+              <goal>create-metadata</goal>
+            </goals>
+            <configuration>
+              <detectedOutputFormat>true</detectedOutputFormat>
+              <revisionOnScmFailure>UNKNOWN</revisionOnScmFailure>
+              <!-- see outputDirectory + outputName for the default outputFile -->
+              <outputFiles>
+                <outputFile>${project.build.directory}/file1.json</outputFile>
+                <outputFile>${project.build.directory}/xxx/file1.json</outputFile>
+              </outputFiles>
+              <addOutputDirectoryToResources>true</addOutputDirectoryToResources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+  </build>
+
+</project>


### PR DESCRIPTION
Hi,
I would appreciate generating the build meta data as json formatted files. So I implemented support for, triggered by a out file name ending with .json and if detectedOutputFormat is enabled to retain compatibility.

If you think it is a valuable feature, please merge or contact me.

Best Regards
conni