### PR TITLE
Reduce number of executed `hg` processes from two to one.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .classpath
 .project
 *.iml
+.idea

--- a/src/main/java/org/codehaus/mojo/build/HgChangeSetMojo.java
+++ b/src/main/java/org/codehaus/mojo/build/HgChangeSetMojo.java
@@ -22,6 +22,7 @@ package org.codehaus.mojo.build;
  */
 
 import java.io.File;
+import java.util.Arrays;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -45,6 +46,8 @@ import org.codehaus.plexus.util.StringUtils;
 public class HgChangeSetMojo
     extends AbstractMojo
 {
+    private static final String TEMPLATE = "\"{date|isodate}\u001f{node|short}\"";
+
     /**
      * Whether to skip this execution.
      *
@@ -107,14 +110,14 @@ public class HgChangeSetMojo
             String previousChangeSetDate = getChangeSetDateProperty();
             if ( previousChangeSet == null || previousChangeSetDate == null )
             {
-                final String changeSetAndDate = getChageSetAndDate();
-                final String[] lines = changeSetAndDate.split("[\\r\\n]+", 2);
-                if ( lines.length != 2 )
+                final String changeSetAndDate = getChangeSetAndDate();
+                final String[] items = changeSetAndDate.split("\\u001f", 2);
+                if ( items.length != 2 )
                 {
-                    throw new MojoExecutionException("Command did not return exactly two lines.");
+                    throw new MojoExecutionException("Command did not return exactly two items.");
                 }
-                final String changeSetDate = lines[0];
-                final String changeSet = lines[1];
+                final String changeSetDate = items[0];
+                final String changeSet = items[1];
                 getLog().info( "Setting Mercurial Changeset: " + changeSet );
                 getLog().info( "Setting Mercurial Changeset Date: " + changeSetDate );
                 setChangeSetProperty( changeSet );
@@ -136,12 +139,12 @@ public class HgChangeSetMojo
         return consumer.getOutput();
     }
 
-    protected String getChageSetAndDate()
+    protected String getChangeSetAndDate()
         throws ScmException, MojoExecutionException
     {
         String[] command = useLastChangeSetInDirectory
-            ? new String[] { "log", "-l1", "--template", "\"{date|isodate}\\n{node|short}\"", "." }
-            : new String[] { "log", "-r", ".", "--template", "\"{date|isodate}\\n{node|short}\"", "." };
+            ? new String[] { "log", "-l1", "--template", TEMPLATE, "." }
+            : new String[] { "log", "-l1", "--template", TEMPLATE };
         return getHgCommandOutput( command );
     }
 


### PR DESCRIPTION
I would like to propose the following change. It reduces the number of executed `hg` processes to one from two, which is a significant speed-up on Windows. There is only tiny difference in the output from the previous state, and that is that `hg id -i` outputs `+` if the working directory has modified files. I find little value in that information as this plugin is likely to be useful only in automation where file modification does not happen. 