### PR TITLE
Fix #70 Check revision existance before calling scm info

### DIFF
--- a/src/main/java/org/codehaus/mojo/build/CreateMojo.java
+++ b/src/main/java/org/codehaus/mojo/build/CreateMojo.java
@@ -275,7 +275,7 @@ public class CreateMojo
                 getLog().debug( "Revision available from previous execution" );
                 return;
             }
-
+            revision = null;
             if ( doCheck )
             {
                 StringBuilder message = new StringBuilder();
@@ -321,7 +321,7 @@ public class CreateMojo
                     getLog().debug( "Updating project files from SCM: skipped." );
                 }
             }
-            revision = getRevision();
+            revision = revision != null ? revision : getRevision();
         }
 
         if ( project != null )


### PR DESCRIPTION
Some (read Perforce) SCM providers do not provide SCM Info implementations. However, their updates will provide the most recent revision. Currently, CreateMojo captures this revision and then unconditionally overwrites it with the call from scm info. This change retains the update revision and uses it, bypassing the call to getRevision() (scm info).