### PR TITLE
Adds SCM Branch to (git) update and avoids master.

### DIFF
--- a/src/main/java/org/codehaus/mojo/build/CreateMojo.java
+++ b/src/main/java/org/codehaus/mojo/build/CreateMojo.java
@@ -552,7 +552,7 @@ public class CreateMojo
 
             ScmProvider scmProvider = scmManager.getProviderByRepository( repository );
 
-            UpdateScmResult result = scmProvider.update( repository, new ScmFileSet( scmDirectory ) );
+            UpdateScmResult result = scmProvider.update( repository, new ScmFileSet( scmDirectory ), getScmBranch() );
 
             if ( result == null )
             {


### PR DESCRIPTION
I figured that issue #35 fails because it's using a method signature that doesn't inform the branch name, which gets defaults to MASTER.

Adding getScmBranch() fixes this behavior, but I can't guarantee that it fixes or breaks things for others SCMs. Also, now it's calling a deprecated method, but the alternative uses a class I don't understand. So someone can improve from this fix.

Could you please help me with tests/validade this?

Signed-off-by: Leonardo Lima <leomrlima@gmail.com>