### PR TITLE
Remove superfluous escape

### DIFF
--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -67,7 +67,7 @@ Usage
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
             <manifestEntries>
-              <Implementation-Build>$\{buildNumber}</Implementation-Build>
+              <Implementation-Build>${buildNumber}</Implementation-Build>
             </manifestEntries>
           </archive>
         </configuration>
@@ -92,7 +92,7 @@ Usage
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
             <manifestEntries>
-              <Implementation-Build>$\{buildNumber}</Implementation-Build>
+              <Implementation-Build>${buildNumber}</Implementation-Build>
             </manifestEntries>
           </archive>
         </configuration>


### PR DESCRIPTION
The '\' prefacing the maven buildNumber variable was visible in the output. This made the resulting pom.xml wrong.