### PR TITLE
Only the first Hg changeset date should be returned

### DIFF
--- a/src/main/java/org/codehaus/mojo/build/HgChangeSetMojo.java
+++ b/src/main/java/org/codehaus/mojo/build/HgChangeSetMojo.java
@@ -141,9 +141,35 @@ public class HgChangeSetMojo
     protected String getChangeSetDate()
         throws ScmException, MojoExecutionException
     {
+        return getFirstDateValue(readChangeSetDate());
+    }
+
+    private String readChangeSetDate()
+            throws ScmException, MojoExecutionException
+    {
         return getHgCommandOutput( useLastChangeSetInDirectory
                         ? new String[] { "log", "-l1", "--template", "\"{date|isodate}\"", "." }
                         : new String[] { "log", "-r", ".", "--template", "\"{date|isodate}\"" } );
+    }
+
+    private String getFirstDateValue(String dateString)
+    {
+        if (isUnexpectedFormat(dateString)) {
+            return dateString;
+        }
+        int secondQMIndex = dateString.indexOf('"', 1);
+        return isTextAfterIndex(dateString, secondQMIndex) ?
+               dateString.substring(0, secondQMIndex + 1) : dateString;
+    }
+
+    private boolean isUnexpectedFormat(String dateString)
+    {
+        return dateString == null || dateString.isEmpty() || dateString.charAt(0) != '"';
+    }
+
+    private boolean isTextAfterIndex(String s, int index)
+    {
+        return index != -1 && index != (s.length() - 1);
     }
 
     protected String getChangeSetDateProperty()


### PR DESCRIPTION
With an alias in hgrc `log = log --follow` (I had this once for short time, removed it quickly as it is rather silly, however it is a legal alias) current `getChangesSetDate` returns a looong string like this:
`"2016-02-09 15:04 +0100""2016-02-09 14:13 +0100""2016-02-06 18:38 +0100""2016-02-06 17:41 +0100""2016-02-06 17:20 +0100""2016-02-06 14:55 +0100""2016-02-04 13:34 +0100""2016-02-04 13:28 +0100""2016-02-04 13:28 +0100""2016-02-03 03:56 +0100""2016-02-03 03:11 +0100"…`, i.e. one date for each log record, all concatenated together. This patch fixes that by returning only the first date from such string.

**Note:** This patch supposes that there cannot be double quote marks within a properly formatted date string. I am not, however, quite sure whether it is so. In case double quote marks within a date string are legal, more sophisticated approach needs to be undertaken.