### PR TITLE
Use released parent pom 50 (instead of snapshot)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.codehaus.mojo</groupId>
     <artifactId>mojo-parent</artifactId>
-    <version>50-SNAPSHOT</version>
+    <version>50</version>
   </parent>
 
   <artifactId>buildnumber-maven-plugin</artifactId>


### PR DESCRIPTION
Since the parent 50 was released a couple of days ago, we can use the release version now.