### PR TITLE
Unify timestampFormat parameter between Create*Mojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
                     <svn>javasvn</svn>
                   </providerImplementations>
                   <useLastCommittedRevision>true</useLastCommittedRevision>
-                  <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+                  <timestampFormat>yyyy-MM-dd</timestampFormat>
                 </configuration>
               </execution>
             </executions>

--- a/src/main/java/org/codehaus/mojo/build/CreateMojo.java
+++ b/src/main/java/org/codehaus/mojo/build/CreateMojo.java
@@ -184,12 +184,20 @@ public class CreateMojo
     private String locale;
 
     /**
-     * Apply this java.text.MessageFormat to the timestamp only (as opposed to the <code>format</code> parameter).
+     * Apply this {@link java.text.SimpleDateFormat} to the timestamp only (as opposed to the <code>format</code> parameter).
      *
      * @since 1.0-beta-2
      */
     @Parameter( property = "maven.buildNumber.timestampFormat" )
     private String timestampFormat;
+
+    /**
+     * The timezone of the generated timestamp. If blank will default to {@link TimeZone#getDefault()}
+     * 
+     * @since 3.0.0
+     */
+    @Parameter( property = "maven.buildNumber.timestampTimeZone", defaultValue = "" )
+    private String timezone;
 
     /**
      * Selects alternative SCM provider implementations. Each map key denotes the original provider type as given in the
@@ -437,7 +445,17 @@ public class CreateMojo
         String timestamp = String.valueOf( now.getTime() );
         if ( timestampFormat != null )
         {
-            timestamp = MessageFormat.format( timestampFormat, new Object[] { now } );
+            if ( timestampFormat.matches( "\\{0,date,[^\\}]+\\}" ) )
+            {
+                getLog().warn( "The timestampFormat parameter now uses java.text.SimpleDateFormat." );
+                getLog().warn( "Please update your POM as support for java.text.MessageFormat may be removed." );
+                timestamp = Utils.createTimestamp( timestampFormat.replaceFirst( "\\{0,date,([^\\}]+)\\}", "$1" ),
+                                                   timezone, now );
+            }
+            else
+            {
+                timestamp = Utils.createTimestamp( timestampFormat, timezone, now );
+            }
         }
 
         getLog().info( MessageFormat.format( "Storing buildNumber: {0} at timestamp: {1}",

--- a/src/main/java/org/codehaus/mojo/build/Utils.java
+++ b/src/main/java/org/codehaus/mojo/build/Utils.java
@@ -36,7 +36,13 @@ public class Utils
 
     public static String createTimestamp( String timestampFormat, String timeZoneId )
     {
-        Date now = Calendar.getInstance().getTime();
+        return createTimestamp( timestampFormat, timeZoneId, null );
+    }
+
+    public static String createTimestamp( String timestampFormat, String timeZoneId, Date now )
+    {
+        if ( null == now )
+            now = Calendar.getInstance().getTime();
 
         if ( StringUtils.isBlank( timestampFormat ) )
         {

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -155,7 +155,7 @@ Usage
 
 +------------------------------------------+
     <configuration>
-      <format>{0,date,yyyy-MM-dd HH:mm:ss}</format>
+      <format>yyyy-MM-dd HH:mm:ss</format>
       <items>
         <item>timestamp</item>
       </items>

--- a/src/test/java/org/codehaus/mojo/build/it/BuildNumberMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/build/it/BuildNumberMojoTest.java
@@ -183,6 +183,27 @@ public class BuildNumberMojoTest
     }
 
     @Test
+    public void legacyTimestampItTest()
+        throws Exception
+    {
+        File projDir = resources.getBasedir( "legacy-timestamp-it" );
+
+        MavenExecution mavenExec = maven.forProject( projDir );
+        MavenExecutionResult result = mavenExec.execute( "clean", "verify" );
+        result.assertLogText( "Please update your POM" );
+
+        File testDir = result.getBasedir();
+        File artifact = new File( testDir, "target/buildnumber-maven-plugin-legacy-timestamp-it-1.0-SNAPSHOT.jar" );
+        JarFile jarFile = new JarFile( artifact );
+        Attributes manifest = jarFile.getManifest().getMainAttributes();
+        jarFile.close();
+        String timestamp = manifest.getValue( "Build-Time" );
+        SimpleDateFormat format = new SimpleDateFormat( "yyyy-MM-dd" );
+        Assert.assertNotNull( format.parse( timestamp ) );
+
+    }
+
+    @Test
     public void failLocalChangeItTest()
         throws Exception
     {

--- a/src/test/projects/MBUILDNUM-83/pom.xml
+++ b/src/test/projects/MBUILDNUM-83/pom.xml
@@ -54,7 +54,7 @@
                   <svn>javasvn</svn>
                 </providerImplementations>
                 <useLastCommittedRevision>true</useLastCommittedRevision>
-                <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+                <timestampFormat>yyyy-MM-dd</timestampFormat>
               </configuration>
             </execution>
           </executions>

--- a/src/test/projects/MOJO-1668/dotSvnDir/pristine/85/85ead35ecb9e8e8eabe052fe4b3156db3e83741e.svn-base
+++ b/src/test/projects/MOJO-1668/dotSvnDir/pristine/85/85ead35ecb9e8e8eabe052fe4b3156db3e83741e.svn-base
@@ -49,7 +49,7 @@
          </providerImplementations>
          <username>foo</username>
          <password>bar</password>
-         <timestampFormat>{0,date,yyyyMMdd_HHmmss}</timestampFormat>
+         <timestampFormat>yyyyMMdd_HHmmss</timestampFormat>
        </configuration>
       </plugin>
       <plugin>

--- a/src/test/projects/MOJO-1668/pom.xml
+++ b/src/test/projects/MOJO-1668/pom.xml
@@ -54,7 +54,7 @@
           </providerImplementations>
           <username>foo</username>
           <password>bar</password>
-          <timestampFormat>{0,date,yyyyMMdd_HHmmss}</timestampFormat>
+          <timestampFormat>yyyyMMdd_HHmmss</timestampFormat>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/projects/basic-it-git/pom.xml
+++ b/src/test/projects/basic-it-git/pom.xml
@@ -42,7 +42,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/basic-it-no-devscm/dotSvnDir/pristine/b8/b87a2294a5074b47315f9fac29b4930d2a2b7ae5.svn-base
+++ b/src/test/projects/basic-it-no-devscm/dotSvnDir/pristine/b8/b87a2294a5074b47315f9fac29b4930d2a2b7ae5.svn-base
@@ -40,7 +40,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/basic-it-no-devscm/dotSvnDir/text-base/pom.xml.svn-base
+++ b/src/test/projects/basic-it-no-devscm/dotSvnDir/text-base/pom.xml.svn-base
@@ -40,7 +40,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/basic-it-no-devscm/pom.xml
+++ b/src/test/projects/basic-it-no-devscm/pom.xml
@@ -40,7 +40,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/basic-it-svnjava/dotSvnDir/pristine/76/76ff7cf8f7fb9790d8c2819c640d641d4ff2093f.svn-base
+++ b/src/test/projects/basic-it-svnjava/dotSvnDir/pristine/76/76ff7cf8f7fb9790d8c2819c640d641d4ff2093f.svn-base
@@ -45,7 +45,7 @@
                   <svn>javasvn</svn>
                 </providerImplementations>            
                 <useLastCommittedRevision>true</useLastCommittedRevision>
-                <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+                <timestampFormat>yyyy-MM-dd</timestampFormat>
               </configuration>
             </execution>
           </executions>

--- a/src/test/projects/basic-it-svnjava/pom.xml
+++ b/src/test/projects/basic-it-svnjava/pom.xml
@@ -52,7 +52,7 @@
                   <svn>javasvn</svn>
                 </providerImplementations>
                 <useLastCommittedRevision>true</useLastCommittedRevision>
-                <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+                <timestampFormat>yyyy-MM-dd</timestampFormat>
               </configuration>
             </execution>
           </executions>

--- a/src/test/projects/basic-it/dotSvnDir/pristine/be/be81b1b83de4bd67f35fdab9bd4707604ab1c092.svn-base
+++ b/src/test/projects/basic-it/dotSvnDir/pristine/be/be81b1b83de4bd67f35fdab9bd4707604ab1c092.svn-base
@@ -38,7 +38,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/basic-it/dotSvnDir/text-base/pom.xml.svn-base
+++ b/src/test/projects/basic-it/dotSvnDir/text-base/pom.xml.svn-base
@@ -38,7 +38,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/basic-it/pom.xml
+++ b/src/test/projects/basic-it/pom.xml
@@ -38,7 +38,7 @@
             </goals>
             <configuration>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/git-basic-it-MBUILDNUM-66/pom.xml
+++ b/src/test/projects/git-basic-it-MBUILDNUM-66/pom.xml
@@ -36,7 +36,7 @@
               <goal>create</goal>
             </goals>
             <configuration>
-              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
+              <timestampFormat>yyyy-MM-dd</timestampFormat>
             </configuration>
           </execution>
         </executions>

--- a/src/test/projects/legacy-timestamp-it/pom.xml
+++ b/src/test/projects/legacy-timestamp-it/pom.xml
@@ -4,12 +4,11 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.codehaus.mojo.it</groupId>
-  <artifactId>buildnumber-maven-plugin-basic-it-clearcase-scm</artifactId>
+  <artifactId>buildnumber-maven-plugin-legacy-timestamp-it</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <scm>
-    <connection>scm:clearcase:mvn_sm_view:load \some-clearcase-path\LATEST</connection>
-    <developerConnection>scm:clearcase:mv_sm_view:load \some-clearcase-path\LATEST</developerConnection>
+    <developerConnection>scm:git:https://github.com/mojohaus/buildnumber-maven-plugin/test/bogus.git</developerConnection>
   </scm>
 
   <build>
@@ -23,27 +22,13 @@
         <version>${it-plugin.version}</version>
         <executions>
           <execution>
-            <id>useLastCommittedRevision</id>
-            <phase>test</phase>
+            <id>legacyTimestampFormat</id>
             <goals>
               <goal>create</goal>
             </goals>
             <configuration>
-              <revisionOnScmFailure>foo</revisionOnScmFailure>
               <useLastCommittedRevision>true</useLastCommittedRevision>
-            </configuration>
-          </execution>
-
-          <execution>
-            <id>timestampFormat</id>
-            <phase>test</phase>
-            <goals>
-              <goal>create</goal>
-            </goals>
-            <configuration>
-              <revisionOnScmFailure>foo</revisionOnScmFailure>
-              <useLastCommittedRevision>true</useLastCommittedRevision>
-              <timestampFormat>yyyy-MM-dd</timestampFormat>
+              <timestampFormat>{0,date,yyyy-MM-dd}</timestampFormat>
             </configuration>
           </execution>
         </executions>
@@ -61,8 +46,7 @@
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
             <manifestEntries>
-              <SCM-Revision>${buildNumber}</SCM-Revision>
-              <Build-Date>${timestamp}</Build-Date>
+              <Build-Time>${timestamp}</Build-Time>
             </manifestEntries>
           </archive>
         </configuration>


### PR DESCRIPTION
This is a refresh of #41, so I kept the original commiter (and most of the original commit message) and retargeted to the current version. I also added a new integration test. Maybe @jgeorgeson wants to review this, too?

- Update CreateMojo to use Utils.createTimestamp()
- Check value of timestampFormat for MessageFormat style and
  warn/convert for backwards compatibility
- Update IT projects with SimpleDateFormat style configuration for
  executions of create goal & add a new test to verify legacy behavior

(Fixes #40 & #41)