### PR TITLE
Updated Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
+# Need trusty distro to work with java <9
+dist: trusty
 language: java
 env:
-  - MAVEN_VERSION=3.2.5
   - MAVEN_VERSION=3.3.9
+  - MAVEN_VERSION=3.5.4
+  - MAVEN_VERSION=3.6.3
 jdk:
   - openjdk7
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 install:
-  - "mvn -N io.takari:maven:0.4.0:wrapper -Dmaven=${MAVEN_VERSION}"
+  # Specify version of io.takari:maven that supports Java 7
+  - "mvn -N io.takari:maven:0.5.0:wrapper -Dmaven=${MAVEN_VERSION}"
   - "./mvnw --show-version --errors --batch-mode test-compile dependency:go-offline"
 script: "./mvnw --show-version --errors --batch-mode -Prun-its clean verify"
 cache:


### PR DESCRIPTION
 - Fixes for Java 7 builds
 - Removed Maven 3.2.5, added 3.5.4 and 3.6.3
 - Changed from oraclejdk8 to openjdk8
 - Added openjdk11