### PR TITLE
Log message should reflect the default property name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .classpath
 .project
 *.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is the [buildnumber-maven-plugin](http://www.mojohaus.org/buildnumber-maven
 ## Releasing
 
 * Make sure `gpg-agent` is running.
+* subversion `svn` is also needed for running tests
 * Make sure all tests pass `mvn clean verify -Prun-its`
 * Execute `mvn -B release:prepare release:perform`
 

--- a/src/main/java/org/codehaus/mojo/build/CreateMojo.java
+++ b/src/main/java/org/codehaus/mojo/build/CreateMojo.java
@@ -459,7 +459,7 @@ public class CreateMojo
         project.getProperties().put( timestampPropertyName, timestamp );
 
         String scmBranch = getScmBranch();
-        getLog().info( "Storing buildScmBranch: " + scmBranch );
+        getLog().info( "Storing scmBranch: " + scmBranch );
         project.getProperties().put( scmBranchPropertyName, scmBranch );
 
         // Add the revision and timestamp properties to each project in the reactor

--- a/src/test/java/org/codehaus/mojo/build/it/BuildNumberMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/build/it/BuildNumberMojoTest.java
@@ -60,7 +60,7 @@ public class BuildNumberMojoTest
         FileUtils.copyDirectoryStructure( new File( testDir, "dotSvnDir" ), new File( testDir, ".svn" ) );
         result = mavenExec.execute( "clean", "verify" );
         result.assertLogText( "Storing buildNumber: 14069" );
-        result.assertLogText( "Storing buildScmBranch: trunk" );
+        result.assertLogText( "Storing scmBranch: trunk" );
 
         File artifact = new File( testDir, "target/buildnumber-maven-plugin-basic-it-1.0-SNAPSHOT.jar" );
         JarFile jarFile = new JarFile( artifact );
@@ -83,7 +83,7 @@ public class BuildNumberMojoTest
         FileUtils.copyDirectoryStructure( new File( testDir, "dotGitDir" ), new File( testDir, ".git" ) );
         result = mavenExec.execute( "clean", "verify" );
         result.assertLogText( "Storing buildNumber: 6d36c746e82f00c5913954f9178f40224497b2f3" );
-        result.assertLogText( "Storing buildScmBranch: master" );
+        result.assertLogText( "Storing scmBranch: master" );
 
         File artifact = new File( testDir, "target/buildnumber-maven-plugin-basic-it-1.0-SNAPSHOT.jar" );
         JarFile jarFile = new JarFile( artifact );
@@ -103,7 +103,7 @@ public class BuildNumberMojoTest
         MavenExecutionResult result = mavenExec.execute( "clean", "verify" );
         File testDir = result.getBasedir();
         result.assertLogText( "Storing buildNumber: foo" );
-        result.assertLogText( "Storing buildScmBranch: UNKNOWN_BRANCH" );
+        result.assertLogText( "Storing scmBranch: UNKNOWN_BRANCH" );
 
         File artifact = new File( testDir, "target/buildnumber-maven-plugin-basic-it-clearcase-scm-1.0-SNAPSHOT.jar" );
         JarFile jarFile = new JarFile( artifact );
@@ -128,7 +128,7 @@ public class BuildNumberMojoTest
         FileUtils.copyDirectoryStructure( new File( testDir, "dotSvnDir" ), new File( testDir, ".svn" ) );
         result = mavenExec.execute( "clean", "verify" );
         result.assertLogText( "Storing buildNumber: 14069" );
-        result.assertLogText( "Storing buildScmBranch: trunk" );
+        result.assertLogText( "Storing scmBranch: trunk" );
 
         File artifact = new File( testDir, "target/buildnumber-maven-plugin-basic-it-no-devscm-1.0-SNAPSHOT.jar" );
         JarFile jarFile = new JarFile( artifact );
@@ -153,7 +153,7 @@ public class BuildNumberMojoTest
         FileUtils.copyDirectoryStructure( new File( testDir, "dotSvnDir" ), new File( testDir, ".svn" ) );
         result = mavenExec.execute( "clean", "verify" );
         result.assertLogText( "Storing buildNumber: 19665" );
-        result.assertLogText( "Storing buildScmBranch: trunk" );
+        result.assertLogText( "Storing scmBranch: trunk" );
 
         File artifact = new File( testDir, "target/buildnumber-maven-plugin-basic-it-svnjava-1.0-SNAPSHOT.jar" );
         JarFile jarFile = new JarFile( artifact );
@@ -235,7 +235,7 @@ public class BuildNumberMojoTest
         FileUtils.fileWrite( foo, "hello" );
         FileUtils.copyDirectoryStructure( new File( basedir, "dotGitDir" ), new File( basedir, ".git" ) );
         result = mavenExec.execute( "verify" );
-        result.assertLogText( "Storing buildScmBranch: master" );
+        result.assertLogText( "Storing scmBranch: master" );
         File testDir = result.getBasedir();
         File artifact = new File( testDir, "target/buildnumber-maven-plugin-basic-it-1.0-SNAPSHOT.jar" );
         JarFile jarFile = new JarFile( artifact );


### PR DESCRIPTION
Issue #146
from `[INFO] Storing buildScmBranch: some-branch` to `[INFO] Storing scmBranch: some-branch` that reflects the default property name here https://github.com/mojohaus/buildnumber-maven-plugin/blob/master/src/main/java/org/codehaus/mojo/build/CreateMojo.java#L225