### PR TITLE
Add 'revisionTimestamp' property

### DIFF
--- a/src/main/java/org/codehaus/mojo/build/AbstractScmMojo.java
+++ b/src/main/java/org/codehaus/mojo/build/AbstractScmMojo.java
@@ -21,6 +21,7 @@ package org.codehaus.mojo.build;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import java.io.File;
+import java.time.OffsetDateTime;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Component;
@@ -293,5 +294,21 @@ public abstract class AbstractScmMojo extends AbstractMojo {
         }
 
         return info.getRevision();
+    }
+
+    protected OffsetDateTime getScmLastChangedDateTime() throws ScmException {
+        ScmRepository repository = getScmRepository();
+
+        InfoScmResult scmResult = info(repository, new ScmFileSet(scmDirectory));
+
+        if (scmResult == null || scmResult.getInfoItems().isEmpty()) {
+            return null;
+        }
+
+        checkResult(scmResult);
+
+        InfoItem info = scmResult.getInfoItems().get(0);
+
+        return info.getLastChangedDateTime();
     }
 }

--- a/src/main/java/org/codehaus/mojo/build/CreateMojo.java
+++ b/src/main/java/org/codehaus/mojo/build/CreateMojo.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.time.OffsetDateTime;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -220,6 +221,25 @@ public class CreateMojo extends AbstractScmMojo {
     @Parameter(property = "maven.buildNumber.scmBranchPropertyName", defaultValue = "scmBranch")
     private String scmBranchPropertyName;
 
+    /**
+     * You can rename the revisionTimestamp property name to another property name if desired.
+     */
+    @Parameter(property = "maven.buildNumber.revisionTimestampPropertyName", defaultValue = "revisionTimestamp")
+    private String revisionTimestampPropertyName;
+
+    /**
+     * Apply this {@link java.time.format.DateTimeFormatter} to the revisionTimestamp.
+     */
+    @Parameter(property = "maven.buildNumber.revisionTimestampFormat")
+    private String revisionTimestampFormat;
+
+    /**
+     * If this is made true, then the plugin will attempt to get the timestamp from the last commited
+     * revision and store in the 'revisionTimestampPropertyName' property
+     */
+    @Parameter(property = "maven.buildNumber.getRevisionTimestamp", defaultValue = "false")
+    private boolean getRevisionTimestamp;
+
     // ////////////////////////////////////// internal maven components ///////////////////////////////////
 
     /**
@@ -238,6 +258,8 @@ public class CreateMojo extends AbstractScmMojo {
     private String revision;
 
     private boolean useScm;
+
+    private OffsetDateTime revisionTimestamp;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         String buildIsTainted = "ok";
@@ -299,6 +321,14 @@ public class CreateMojo extends AbstractScmMojo {
                 }
             }
             revision = getRevision();
+        }
+
+        if (getRevisionTimestamp) {
+            try {
+                revisionTimestamp = getScmLastChangedDateTime();
+            } catch (ScmException e) {
+                getLog().warn("Error getting SCM last changed datetime: " + e);
+            }
         }
 
         if (project != null) {
@@ -393,6 +423,15 @@ public class CreateMojo extends AbstractScmMojo {
             project.getProperties().put(buildNumberPropertyName, revision);
         }
         project.getProperties().put(timestampPropertyName, timestamp);
+
+        if (getRevisionTimestamp) {
+            String revisionTimestampStr = String.valueOf(revisionTimestamp);
+            if (revisionTimestampFormat != null) {
+                revisionTimestampStr = Utils.createTimestamp(revisionTimestampFormat, revisionTimestamp);
+            }
+            getLog().info(MessageFormat.format("Storing revisionTimestamp: {0}", revisionTimestampStr));
+            project.getProperties().put(revisionTimestampPropertyName, revisionTimestampStr);
+        }
 
         String scmBranch = getScmBranch();
         getLog().info("Storing scmBranch: " + scmBranch);

--- a/src/main/java/org/codehaus/mojo/build/Utils.java
+++ b/src/main/java/org/codehaus/mojo/build/Utils.java
@@ -21,6 +21,8 @@ package org.codehaus.mojo.build;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import java.text.SimpleDateFormat;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
@@ -43,6 +45,15 @@ public class Utils {
             SimpleDateFormat dateFormat = new SimpleDateFormat(timestampFormat);
             dateFormat.setTimeZone(getTimeZone(timeZoneId));
             return dateFormat.format(now);
+        }
+    }
+
+    public static String createTimestamp(String timestampFormat, OffsetDateTime dateTime) {
+        if (StringUtils.isBlank(timestampFormat)) {
+            return String.valueOf(dateTime);
+        } else {
+            DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern(timestampFormat);
+            return dateTime.format(dateFormat);
         }
     }
 


### PR DESCRIPTION
BuildNumber's CreateMojo can generate the `timestamp` property if desired, but this property is generated at buildtime and thus is not reproducible. I propose to create a new property based on the last commit timestamp, named `revisionTimestamp` by default.

For this reason, I suggest creating 3 new properties in CreateMojo:

- `maven.buildNumber.getRevisionTimestamp` (boolean value): when true generates the revision timestamp property (`revisionTimestamp` by default)

- `maven.buildNumber.revisionTimestampPropertyName`: is used to rename the revision timestamp property

- `maven.buildNumber.revisionTimestampFormat`: the timestamp format to be used (uses `java.time.format.DateTimeFormatter`). If not set, `java.time.OffsetDateTime` will format the timestamp in ISO-8601 (like `2026-07-29T18:40:00-03:00`)

The revision timestamp may also be used to set the property for reproducible builds, `project.build.outputTimestamp`. To achieve this one must set `maven.buildNumber.revisionTimestampPropertyName` property to `project.build.outputTimestamp`.
